### PR TITLE
Add format provider

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -285,50 +285,6 @@ export const config: atomConfig = {
     type: "object",
     order: 3,
     properties: {
-      onSave: {
-        title: "Format on save",
-        type: "object",
-        order: 1,
-        properties: {
-          enable: {
-            title: "enables",
-            type: "boolean",
-            default: true,
-            order: 1,
-          },
-          extensions: {
-            title: "File type to enable",
-            type: "object",
-            order: 2,
-            properties: {
-              "source_js": {
-                title: "JavaScript",
-                type: "boolean",
-                default: true,
-                order: 1,
-              },
-              "source_ts": {
-                title: "TypeScript",
-                type: "boolean",
-                default: true,
-                order: 2,
-              },
-              "source_gfm": {
-                title: "markdown",
-                type: "boolean",
-                default: true,
-                order: 3,
-              },
-              "source_json": {
-                title: "json",
-                type: "boolean",
-                default: true,
-                order: 4,
-              },
-            },
-          },
-        },
-      },
       onCommand: {
         title: "Format on command",
         type: "object",

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -53,7 +53,7 @@ class DenoLanguageClient extends AutoLanguageClient {
       "source.tsx",
       "JavaScript",
       "TypeScript",
-      //'source.gfm', <-not supported at deno lsp
+      "source.gfm",
       "source.json",
     ];
   }
@@ -445,28 +445,5 @@ function onActivate(denoLS: DenoLanguageClient) {
           ]),
       ),
     ),
-    // save on format
-    atom.workspace.observeTextEditors((editor) => {
-      denoLS.subscriptions?.add(
-        editor.onDidSave(({ path }) => {
-          if (!atom.config.get("atom-ide-deno.format.onSave.enable")) {
-            // console.log(`ignored format(disabled): ${path}`);
-            return;
-          }
-          if (
-            !atom.config.get(
-              `atom-ide-deno.format.onSave.extensions.${
-                editor.getGrammar().scopeName.replace(/\./g, "_")
-              }`,
-            )
-          ) {
-            // console.log(`ignored format(exclude extension): ${path}`);
-            return;
-          }
-          // console.log(`format: ${path}`);
-          formatter.formatFile(getDenoPath(), [], path);
-        }),
-      );
-    }),
   );
 }

--- a/package.json
+++ b/package.json
@@ -106,24 +106,24 @@
         "0.1.0": "provideFindReferences"
       }
     },
-    "__code-format.range": {
+    "code-format.range": {
       "versions": {
         "0.1.0": "provideRangeCodeFormat"
       }
     },
-    "__code-format.file": {
+    "code-format.file": {
       "versions": {
         "0.1.0": "provideFileCodeFormat"
       }
     },
-    "__code-format.onSave": {
-      "versions": {
-        "0.1.0": "provideOnSaveCodeFormat"
-      }
-    },
-    "__code-format.onType": {
+    "code-format.onType": {
       "versions": {
         "0.1.0": "provideOnTypeCodeFormat"
+      }
+    },
+    "code-format.onSave": {
+      "versions": {
+        "0.1.0": "provideOnSaveCodeFormat"
       }
     },
     "code-highlight": {


### PR DESCRIPTION
Makes use of the atom-ide-code-format to format on save.
https://github.com/atom-community/atom-ide-code-format

We should be able to use atom-ide-code-format for the Format Current File command as well, but I'm getting an error so leave it alone.