### PR TITLE
Workaround for "deno:/" URL

### DIFF
--- a/lib/connection_hook.ts
+++ b/lib/connection_hook.ts
@@ -1,0 +1,129 @@
+import type { LanguageClientConnection } from "atom-languageclient";
+import type {
+  KnownNotifications,
+  KnownRequests,
+  RequestCallback,
+} from "atom-languageclient/build/lib/languageclient";
+import type * as lsp from "vscode-languageserver-protocol";
+import type * as jsonrpc from "vscode-jsonrpc";
+import { addHook, addHookToObject } from "./utils/hook";
+
+// Hack: Intervene in the connection with lsp and rewrite the URL of the request.
+// Rewrite messages starting with `deno: /` to `deno-code: //`.
+// If this is not done, the path will be interpreted as a relative path and any error will occur.
+
+function transStringInObject(arg: any, trans: (arg: string) => string): any {
+  if (!arg) {
+    return arg;
+  } else if (typeof arg === "string") {
+    return trans(arg);
+  } else if (typeof arg === "object" && typeof arg.then === "function") {
+    return arg.then((v: any) => transStringInObject(v, trans));
+  } else if (Object.prototype.toString.call(arg) === "[object Object]") {
+    return Object.fromEntries(
+      Object.entries(arg).map(([k, v]) => [k, transStringInObject(v, trans)]),
+    );
+  } else if (Array.isArray(arg)) {
+    return arg.map((v) => transStringInObject(v, trans));
+  } else {
+    return arg;
+  }
+}
+
+function encodeDenoURI<T>(arg: T): T {
+  return transStringInObject(
+    arg,
+    (v) => v.replace(/^deno:\/(?!\/)/, "deno-code://"),
+  );
+}
+function decodeDenoURI<T>(arg: T): T {
+  return transStringInObject(
+    arg,
+    (v) => v.replace(/^deno-code:\/\//, "deno:/"),
+  );
+}
+
+export function addHookToConnection(conn_: LanguageClientConnection) {
+  const conn = conn_ as unknown as HookedLanguageClientConnection;
+  type onRequestArgs = Parameters<HookedLanguageClientConnection["_onRequest"]>;
+  addHookToObject(conn, "_onRequest", {
+    argumentsHook([a, callback, ...others]: onRequestArgs): onRequestArgs {
+      return [
+        a,
+        addHook(callback, {
+          argumentsHook: encodeDenoURI,
+          returnHook: decodeDenoURI,
+        }),
+        ...others,
+      ];
+    },
+  });
+  type onNotificationArgs = Parameters<
+    HookedLanguageClientConnection["_onNotification"]
+  >;
+  addHookToObject(conn, "_onNotification", {
+    argumentsHook(
+      [a, callback, ...others]: onNotificationArgs,
+    ): onNotificationArgs {
+      return [
+        a,
+        addHook(callback, { argumentsHook: encodeDenoURI }),
+        ...others,
+      ];
+    },
+  });
+  type sendNotificationArgs = Parameters<
+    HookedLanguageClientConnection["_sendNotification"]
+  >;
+  addHookToObject(conn, "_sendNotification", {
+    argumentsHook(
+      [a, b, ...others]: sendNotificationArgs,
+    ): sendNotificationArgs {
+      return [
+        a,
+        decodeDenoURI(b),
+        ...others,
+      ];
+    },
+  });
+  type sendRequestArgs = Parameters<
+    HookedLanguageClientConnection["_sendRequest"]
+  >;
+  addHookToObject(conn, "_sendRequest", {
+    argumentsHook([a, b, ...others]: sendRequestArgs): sendRequestArgs {
+      return [
+        a,
+        decodeDenoURI(b),
+        ...others,
+      ];
+    },
+    returnHook: encodeDenoURI,
+  });
+}
+
+interface HookedLanguageClientConnection {
+  _onRequest<T extends Extract<keyof KnownRequests, string>>(
+    type: { method: T },
+    callback: RequestCallback<T>,
+  ): void;
+
+  _onNotification<T extends Extract<keyof KnownNotifications, string>>(
+    type: { method: T },
+    callback: (obj: KnownNotifications[T]) => void,
+  ): void;
+
+  _sendNotification<P, RO>(
+    protocol:
+      | lsp.ProtocolNotificationType<P, RO>
+      | lsp.ProtocolNotificationType0<RO>,
+    args?: P,
+  ): void;
+
+  _sendRequest<P, R, PR, E, RO>(
+    protocol:
+      | lsp.ProtocolRequestType<P, R, PR, E, RO>
+      | lsp.ProtocolRequestType0<R, PR, E, RO>,
+    args?: P,
+    cancellationToken?: jsonrpc.CancellationToken,
+  ): Promise<R>;
+}

--- a/lib/connection_hook.ts
+++ b/lib/connection_hook.ts
@@ -30,12 +30,14 @@ function transStringInObject(arg: any, trans: (arg: string) => string): any {
   }
 }
 
+/** convert message from server to Atom */
 function encodeDenoURI<T>(arg: T): T {
   return transStringInObject(
     arg,
     (v) => v.replace(/^deno:\/(?!\/)/, "deno-code://"),
   );
 }
+/** convert message from Atom to server */
 function decodeDenoURI<T>(arg: T): T {
   return transStringInObject(
     arg,

--- a/lib/utils/hook.ts
+++ b/lib/utils/hook.ts
@@ -1,0 +1,43 @@
+/** Hook the argument value with {argumentsHook} and the return value with {returnHook} for the {property} of {target}. */
+export function addHookToObject<
+  A extends Array<any>,
+  R,
+  P extends string | number | symbol,
+  T extends {
+    [k in P]: (...args: A) => R;
+  },
+>(
+  target: T,
+  property: P,
+  {
+    argumentsHook,
+    returnHook,
+  }: FunctionHooks<A, R>,
+) {
+  target[property] = <T[P]> addHook(
+    target[property],
+    { argumentsHook, returnHook },
+    target,
+  );
+}
+
+/** Hook the argument value with {argumentsHook} and the return value with {returnHook} for the {originalFunction}. The value of {thisArg} is set to {this} of the {originalFunction}. */
+export function addHook<A extends Array<any>, R>(
+  originalFunction: (...args: A) => R,
+  {
+    argumentsHook,
+    returnHook,
+  }: FunctionHooks<A, R>,
+  thisArg?: any,
+): (...args: A) => R {
+  return ((...args: A) => {
+    const newArgs = argumentsHook ? argumentsHook(args) : args;
+    const returns = originalFunction.apply(thisArg, newArgs);
+    return returnHook ? returnHook(returns) : returns;
+  });
+}
+
+export interface FunctionHooks<A, R> {
+  argumentsHook?: (arg: A) => A;
+  returnHook?: (arg: R) => R;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -354,9 +354,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew=="
+      "version": "4.4.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.0-beta.tgz",
+      "integrity": "sha512-qMxA8NzN3igwX8Mii7MXGNW+YeFAkUKyKg+x4F1CCFsO36LqISf1EXXSOLDuRIdGjdVvV53grRxfHjOW65YfMA=="
     },
     "vscode-jsonrpc": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "atom-languageclient": "^1.14.1",
     "atom-package-deps": "^7.2.3",
     "atom-ts-transpiler": "^1.5.3",
-    "typescript": "~4.3.4"
+    "typescript": "^4.4.0-beta"
   },
   "devDependencies": {
     "@types/atom": "^1.40.11",


### PR DESCRIPTION
Hack: Intervene in the connection with lsp and rewrite the URL of the request.
Rewrite messages starting with `deno: /` to `deno-code: //`.
If this is not done, the path will be interpreted as a relative path and any error will occur.

![image](https://user-images.githubusercontent.com/40050810/126086313-f0d8b2c2-8f1d-4513-be1a-b3bfe7854cfe.png)

This allows we to open virtual documents.